### PR TITLE
Fix left/right associativity issues & add more operators

### DIFF
--- a/core.rkt
+++ b/core.rkt
@@ -7,7 +7,7 @@
 (provide
  ;; private/parse
  prop:infix-procedure
- infix-app infix-default jx-cons
+ infix-app infix-default fn-application-cons
  infix-local-table with-infix-binding
  infix-local-value infix-lookup-syntax
  infix-parse infix-parse-all

--- a/math.rkt
+++ b/math.rkt
@@ -1,4 +1,17 @@
 #lang racket/base
+(provide (rename-out [add +]
+                     [mul *]
+                     [sub -]
+                     [div /]
+                     [pow ^]
+                     [eq-op =]
+                     [geq-op >=]
+                     [leq-op <=]
+                     [gt-op >]
+                     [le-op <]
+                     [#%parse $])
+         #%fn-application #%parens)
+
 (require infix-syntax/define
          (rename-in racket/base)
          (for-syntax racket/base
@@ -11,7 +24,6 @@
     [(_ name id get)
      (define-operator name #:com #'id #:get get)]))
 
-
 (def-op add + 4 left-assoc)
 (def-op sub - 4 left-assoc)
 (def-op mul * 5 left-assoc)
@@ -23,33 +35,19 @@
 (def-op gt-op > 1 right-assoc)
 (def-op le-op < 1 right-assoc)
 
-
-(define-infix (#%jx l in)
+(define-infix (#%fn-application l in)
   #:precedence 9
   (with-right [r (right-assoc 9 in)]
     #:syntax (l r)
-    #'(#%jx l r))
+    #'(#%fn-application l r))
   #:expand
-  (λ(stx)
-    (syntax-case stx (#%jx)
-      [(_ (#%jx x ...) y ...)
-       #'(#%jx x ... y ...)]
+  (λ (stx)
+    (syntax-case stx (#%fn-application)
+      [(_ (#%fn-application x ...) y ...)
+       #'(#%fn-application x ... y ...)]
       [(_ x ...) #'(x ...)])))
 
-(define-infix (#%parens l in)
-  (if l (infix-default l in)
-      (with-syntax ([(x ...)(car in)])
-        (values #'(#%parse x ...) (cdr in)))))
-
-(provide (rename-out [add +]
-                     [mul *]
-                     [sub -]
-                     [div /]
-                     [pow ^]
-                     [eq-op =]
-                     [geq-op >=]
-                     [leq-op <=]
-                     [gt-op >]
-                     [le-op <]
-                     [#%parse $])
-         #%jx #%parens)
+(define-infix (#%parens head rest)
+  (if head (infix-default head rest)
+      (with-syntax ([(x ...) (car rest)])
+        (values #'(#%parse x ...) (cdr rest)))))

--- a/math.rkt
+++ b/math.rkt
@@ -15,9 +15,13 @@
 (def-op add + 4 left-assoc)
 (def-op sub - 4 left-assoc)
 (def-op mul * 5 left-assoc)
-(def-op div / 5 right-assoc)
-
-(def-op eq-op = 1 left-assoc)
+(def-op div / 5 left-assoc)
+(def-op pow expt 6 right-assoc)
+(def-op eq-op = 1 right-assoc)
+(def-op geq-op >= 1 right-assoc)
+(def-op leq-op <= 1 right-assoc)
+(def-op gt-op > 1 right-assoc)
+(def-op le-op < 1 right-assoc)
 
 
 (define-infix (#%jx l in)
@@ -41,6 +45,11 @@
                      [mul *]
                      [sub -]
                      [div /]
+                     [pow ^]
                      [eq-op =]
+                     [geq-op >=]
+                     [leq-op <=]
+                     [gt-op >]
+                     [le-op <]
                      [#%parse $])
          #%jx #%parens)

--- a/private/prec.rkt
+++ b/private/prec.rkt
@@ -36,12 +36,12 @@
     [(e in R m) (infix-parse  e in (cmp-prec R m))]
     [(  in R m) (infix-parse #f in (cmp-prec R m))]))
 
-(define left-assoc
+(define right-assoc
   (case-lambda
     [(prec in)(infix-parse/cmp #f (cdr in) <  prec)]
     [(prec)(λ(in)(left-assoc prec in))]))
 
-(define right-assoc
+(define left-assoc
   (case-lambda
     [(prec in)(infix-parse/cmp #f (cdr in) <= prec)]
     [(prec)(λ(in)(left-assoc prec in))]))

--- a/test/02-core-parse.rkt
+++ b/test/02-core-parse.rkt
@@ -60,7 +60,7 @@
 (def-tag #%parens   3 |()|)
 (def-tag #%brackets 3 |[]|)
 (def-tag #%braces   3 |{}|)
-(def-op/r #%jx l 1)
+(def-op/r #%fn-application l 1)
 
 (define-syntax a=>
   (tok do-a=> 3))
@@ -74,7 +74,7 @@
 (check-parsed-equal? [1 ol1  2]   (ol1 1 2))
 (check-parsed-equal? [  ol1  2]   (ol1   2))
 (check-parsed-equal? [1 opf1  ]  (opf1 1  ))
-(check-parsed-equal? [1      2]  (#%jx 1 2))
+(check-parsed-equal? [1      2]  (#%fn-application 1 2))
 (check-parsed-equal? [ (1)]      (|()|   1))
 (check-parsed-equal? [f(1)]      (|()| f 1))
 (check-parsed-equal? [ [1]]      (|[]|   1))
@@ -145,7 +145,7 @@
 
 (check-parsed-equal?
  [1 2 3 4 5 6 7]
- (#%jx (#%jx (#%jx (#%jx (#%jx (#%jx 1 2) 3) 4) 5) 6) 7))
+ (#%fn-application (#%fn-application (#%fn-application (#%fn-application (#%fn-application (#%fn-application 1 2) 3) 4) 5) 6) 7))
 
 (check-parsed-equal?
  [   1   ol1    2    ol1     3     ol1    4    ol1    5   ]


### PR DESCRIPTION
Left/right associativity now work as expected and I added some more operators such as `expt` and `>=`. Tests run fine for me.